### PR TITLE
make the format compatible with a few Android App including

### DIFF
--- a/pynfc/class_nfc.py
+++ b/pynfc/class_nfc.py
@@ -267,7 +267,7 @@ class NFCconnection(object):
                 pass
         
         print(f"Read payload in bytes: {data}")
-        payload = data[5:index_end]
+        payload = data[2:index_end]
         # print(f"payload is: {payload}")
 
         # decode payload
@@ -327,14 +327,14 @@ class NFCconnection(object):
         print(f"data converted = {databytes}")
 
         # metadata of payload
-        recordlength = len(databytes) + 7
+        recordlength = len(databytes)
         datalength = len(databytes) + 3
 
         if recordlength > size:
             print("Failed: card size is too small for payload")
 
         # build payload
-        payload = [3, recordlength, 209, 1, datalength] + list(databytes) + [254]
+        payload = [3, recordlength] + list(databytes) + [254]
         print(f"payload data = {payload}")
 
         payloadlength = len(payload)

--- a/test_class_nfc.py
+++ b/test_class_nfc.py
@@ -1,6 +1,6 @@
 import ndef
 
-from pynfc.pyscard_ndeflib import (
+from pynfc.class_nfc import (
     NFCconnection,
     decode_message_text,
     encode_message_text,


### PR DESCRIPTION
NXP TagInfo, NXP TagWriter, NFC TagInfo.
The current code can write the data into NFC chip. However a few famous App can not recognize the format. The modified version removed 3 bytes ahead of the first NDEF record. Now the format is compatible. Tested on Android phone