### PR TITLE
Added NTAG21x type

### DIFF
--- a/pynfc/class_nfc.py
+++ b/pynfc/class_nfc.py
@@ -173,7 +173,7 @@ class NFCconnection(object):
             data_hex = "FF"
             if "OMNIKEY 5022" in self.metadata["reader"]: 
                 data_hex = "FF680E030B1F08000000000000000060"
-            elif "ACR122U" in self.metadata["reader"]:
+            elif "ACR122" in self.metadata["reader"]:
                 offset = 3
                 data_hex = "FF00000003D44260"
 
@@ -248,7 +248,7 @@ class NFCconnection(object):
 
         card_type = self.metadata["ATR"]["card_type"]
         subtype = self.metadata["ATR"]["card_subtype"]
-        if card_type == "Mifare Ultralight EV1" and "NTAG" in subtype:
+        if card_type in ["Mifare Ultralight EV1","Mifare Ultralight"] and "NTAG" in subtype:
             return
         # retrieving length of card
         page = 1

--- a/pynfc/class_nfc.py
+++ b/pynfc/class_nfc.py
@@ -12,6 +12,7 @@ from smartcard.CardType import ATRCardType, AnyCardType
 from smartcard.CardRequest import CardRequest
 from smartcard.CardConnection import CardConnection
 from smartcard.System import readers
+from smartcard.util import toBytes
 
 from .class_conversions import (
     ConvertingArrays,
@@ -162,6 +163,43 @@ class NFCconnection(object):
         if card_type == "Unknown":
             card_type += f" - card name code: -{card_type_string}-"
 
+        subtype = "Unknown"
+        if card_type == "Mifare Ultralight EV1" : # only using omnikey 5022CL
+            size = 144
+            data_hex = "FF680E030B1F08000000000000000060"
+            data = toBytes(data_hex)
+            apdu_command = data
+            response, sw1, sw2 = self.cardservice.connection.transmit(apdu_command)
+            if sw1 == 144:
+                (vender_id, product_type,product_subtype, major_version, storage_code) = (response[3],response[4],response[5],response[6],response[8])
+                if vender_id == 4:
+                    vender = "NXP" 
+                if product_type == 4: # General NTAG
+                    size = 0
+                    subtype = "NTAG"
+                    if major_version == 1: # NTAG210, 212,213,215,216
+                        if product_subtype == 0x01: # 17pF ,NTAG210,212
+                            if storage_code == 0x0B:
+                                subtype == "NTAG210"
+                                size = 48
+                            if storage_code == 0x0E:
+                                subtype == "NTAG212"
+                                size = 128
+                        if product_subtype == 0x02: # 50pF, NTAG213,215,216
+                            if storage_code == 0x0F:
+                                subtype == "NTAG213"
+                                size = 144 
+                            if storage_code == 0x11:
+                                subtype == "NTAG215"
+                                size = 504
+                            if storage_code == 0x13:
+                                subtype == "NTAG216"
+                                size = 888
+                    if major_version == 3: #NTAG213TT
+                        if storage_code == 0x0F:
+                            subtype == "NTAG213TT"
+                            size =  144
+
         # something to do with clock frequencies, are often left at 0 to set default setting.
         rfu = "Unknown"
         info = "Radio Frequency Units (RFUs)"
@@ -177,8 +215,12 @@ class NFCconnection(object):
         if rfu == "Unknown":
             rfu += f" - card name code: -{rfu_string}-"
 
-        atr_info = {"ATRraw": atr, "hist byte count": hist_byte_count, "length": length, "rid": rid, "standard": standard, "card_type": card_type, "rfu": rfu}
+        atr_info = {"ATRraw": atr, "hist byte count": hist_byte_count, "length": length, "rid": rid, "standard": standard, 
+                    "card_type": card_type, "rfu": rfu,"card_subtype":subtype}
         self.metadata = {"ATR": atr_info}
+        if size:
+            self.metadata.update({"Size": size})
+
 
     def get_card_uid(self):
 
@@ -195,6 +237,10 @@ class NFCconnection(object):
 
     def get_card_size(self):
 
+        card_type = self.metadata["ATR"]["card_type"]
+        subtype = self.metadata["ATR"]["card_subtype"]
+        if card_type == "Mifare Ultralight EV1" and "NTAG" in subtype:
+            return
         # retrieving length of card
         page = 1
         sw1 = 144
@@ -433,6 +479,13 @@ class NFCconnection(object):
 
         print(f"Success: NFC written to card: {payload}")
         return "Success"
+    
+    def send_raw_command(self, data):
+        response, sw1, sw2 = self.cardservice.connection.transmit(data)
+        if sw1 != 90:
+            print(f"Failed sending raw command. sw1,sw2: {sw1},{sw2}")
+            return "Failed"
+        return bytes(response)
 
 
 # NDEFlib decoder and encoder of simple text messages

--- a/pynfc/class_nfc.py
+++ b/pynfc/class_nfc.py
@@ -168,7 +168,7 @@ class NFCconnection(object):
             card_type += f" - card name code: -{card_type_string}-"
         size = 0
         subtype = "Unknown"
-        if card_type in ["Mifare Ultralight EV1","Mifare Ultralight"]: # only using omnikey 5022CL
+        if card_type in ["Mifare Ultralight EV1","Mifare Ultralight"]: # only tested on omnikey 5022CL and ACR122U
             offset = 2
             data_hex = "FF"
             if "OMNIKEY 5022" in self.metadata["reader"]: 

--- a/pynfc/nfc_communication.json
+++ b/pynfc/nfc_communication.json
@@ -35,6 +35,7 @@
                 "Mifare 1K": ["0x0", "0x1"],
                 "Mifare 4k": ["0x0", "0x2"],
                 "Mifare Ultralight": ["0x0", "0x3"],
+				"Mifare Ultralight EV1": ["0x0","0x3d"],
                 "Mifare Mini": ["0x0", "0x26"],
                 "Topaz and Jewel": ["0xF0", "0x4"],
                 "Felica 212k": ["0xF0", "0x11"],
@@ -88,5 +89,44 @@
                 }
             }
         }
-    }
+    },
+    "Mifare Ultralight EV1": {
+        "Identify": {
+            "APDU_int": [255, 202, 0, 0, 0],
+            "APDU_hex": ["0xFF", "0xCA", "0x0", "0x0", "0x0"],
+            "Response": {}
+        },
+        "Read": {
+            "APDU_int": [255, 176, 0, "block",  16],
+            "APDU_hex": ["0xFF", "0xB0", "0x0", "block", "0x10"],
+            "Response": {
+                "text": {
+                    "start": {
+                        "block": 6,
+                        "byte": 3
+                    },
+                    "end": {
+                        "type": "encounter",
+                        "at": 254
+                    }
+                }
+            }
+        },
+        "Write": {
+            "APDU_int": [255, 214, 0, "block", 4],
+            "APDU_hex": ["0xFF", "0xD6", "0x0", "block", "0x4"],
+            "Response": {
+                "text": {
+                    "start": {
+                        "block": 6,
+                        "byte": 3
+                    },
+                    "end": {
+                        "type": "encounter",
+                        "at": 254
+                    }
+                }
+            }
+        }
+    }	
 }


### PR DESCRIPTION
Hi Micheal, 
I added some new functions to identify NTAG21x tags which are subtype of Mifare Ultralight or Mifare Untralight EV1 (depending on which reader, I tested 2 readers)  base on ATR response but never claimed by NXP.  I also added two more functions for reading/writing raw data. Didn't disrupt exisiting  behaviours other than restored the external json file for get_reference_material()